### PR TITLE
Changing how New users are managed, admin pages, save() clean() methods fixed  

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -22,5 +22,12 @@
       <jdbc-url>jdbc:postgresql://104.198.101.205:5432/barbuddy</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="CoTex@Localhost" uuid="5e0274df-958a-4fba-97f2-d2c3d3483f3a">
+      <driver-ref>postgresql</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>org.postgresql.Driver</jdbc-driver>
+      <jdbc-url>jdbc:postgresql://localhost:5435/brandon</jdbc-url>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
   </component>
 </project>

--- a/backend/apps/matches/admin.py
+++ b/backend/apps/matches/admin.py
@@ -1,3 +1,46 @@
 from django.contrib import admin
+from .models import Match
+from apps.users.models import User
 
-# Register your models here.
+@admin.register(Match)
+class MatchAdmin(admin.ModelAdmin):
+    list_display = ('id', 'user1', 'user2', 'status', 'created_at', 'disconnected_by')
+    list_filter = ('status', 'created_at')
+    search_fields = ('user1__username', 'user2__username', 'user1__email', 'user2__email')
+    # Remove raw_id_fields to use the standard select widget instead
+    # raw_id_fields = ('user1', 'user2', 'disconnected_by')
+    date_hierarchy = 'created_at'
+    list_per_page = 25
+    
+    fieldsets = (
+        ('Match Information', {
+            'fields': ('user1', 'user2', 'status')
+        }),
+        ('Additional Information', {
+            'fields': ('disconnected_by', 'created_at')
+        }),
+    )
+    readonly_fields = ('created_at',)
+    
+    def get_readonly_fields(self, request, obj=None):
+        # Make disconnected_by read-only if status isn't disconnected
+        if obj and obj.status != 'disconnected':
+            return self.readonly_fields + ('disconnected_by',)
+        return self.readonly_fields
+    
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        # For new objects, provide all users in the dropdown
+        if db_field.name in ["user1", "user2"]:
+            kwargs["queryset"] = User.objects.all().order_by('username')
+        
+        # For existing objects, limit disconnected_by choices to only user1 and user2
+        if db_field.name == "disconnected_by" and request.resolver_match.kwargs.get('object_id'):
+            match_id = request.resolver_match.kwargs.get('object_id')
+            try:
+                match = Match.objects.get(id=match_id)
+                kwargs["queryset"] = User.objects.filter(
+                    id__in=[match.user1_id, match.user2_id]
+                )
+            except Match.DoesNotExist:
+                pass
+        return super().formfield_for_foreignkey(db_field, request, **kwargs)

--- a/backend/apps/swipes/admin.py
+++ b/backend/apps/swipes/admin.py
@@ -1,0 +1,46 @@
+from django.contrib import admin
+from .models import Swipe
+
+@admin.register(Swipe)
+class SwipeAdmin(admin.ModelAdmin):
+    list_display = ('id', 'swiper', 'swiped_on', 'status', 'timestamp')
+    list_filter = ('status', 'timestamp')
+    search_fields = ('swiper__username', 'swiped_on__username', 'swiper__email', 'swiped_on__email')
+    raw_id_fields = ('swiper', 'swiped_on')
+    date_hierarchy = 'timestamp'
+    list_per_page = 25
+    
+    fieldsets = (
+        ('Swipe Information', {
+            'fields': ('swiper', 'swiped_on', 'status')
+        }),
+        ('Additional Information', {
+            'fields': ('timestamp',)
+        }),
+    )
+    readonly_fields = ('timestamp',)
+    
+    def save_model(self, request, obj, form, change):
+        """
+        Custom save to ensure match creation happens as it would in the model's save method.
+        This ensures admin-created swipes trigger matches correctly.
+        """
+        super().save_model(request, obj, form, change)
+        
+        # Display a helpful message after creating a "like" swipe
+        if obj.status == 'like':
+            # Check if this created a match
+            from apps.matches.models import Match
+            user1, user2 = sorted([obj.swiper, obj.swiped_on], key=lambda u: u.id)
+            match_exists = Match.objects.filter(user1=user1, user2=user2).exists()
+            
+            if match_exists:
+                self.message_user(
+                    request, 
+                    f"A match was created between {obj.swiper.username} and {obj.swiped_on.username}!"
+                )
+            else:
+                self.message_user(
+                    request,
+                    f"Swipe recorded, but no match created yet. Waiting for {obj.swiped_on.username} to like {obj.swiper.username}."
+                )

--- a/backend/apps/users/admin.py
+++ b/backend/apps/users/admin.py
@@ -1,21 +1,123 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from django.contrib.auth import get_user_model
+from django.contrib.auth.forms import UserCreationForm, UserChangeForm
+from django import forms
 from .models import ProfilePicture
+from django.shortcuts import render, redirect
+from django.urls import path
+from .serializers import ProfilePictureSerializer
 
 User = get_user_model()
 
+class CustomUserCreationForm(UserCreationForm):
+    email = forms.EmailField(required=True)
+    
+    class Meta(UserCreationForm.Meta):
+        model = User
+        fields = ('username', 'email')
+    
+    def clean_email(self):
+        # Just return the email, we'll handle uniqueness in save()
+        return self.cleaned_data.get('email')
+        
+    def save(self, commit=True):
+        user = super().save(commit=False)
+        user.email = self.cleaned_data['email']
+        
+        # Set a flag to skip email validation in the model's clean method
+        user._skip_email_validation = True
+        
+        if commit:
+            user.save()
+        return user
+
 class ProfilePictureInline(admin.TabularInline):
     model = ProfilePicture
-    extra = 1
+    extra = 0  # Don't show empty forms by default
+    readonly_fields = ('preview_image',)
+    fields = ('image', 'is_primary', 'preview_image')
+    
+    def preview_image(self, obj):
+        if obj.image:
+            return f'<img src="{obj.image.url}" width="150" />'
+        return "No image"
+    preview_image.allow_tags = True
+    preview_image.short_description = 'Preview'
+    
+    def get_queryset(self, request):
+        # Only show existing profile pictures
+        qs = super().get_queryset(request)
+        return qs
+
+class UploadPictureForm(forms.Form):
+    image = forms.ImageField()
 
 @admin.register(User)
 class CustomUserAdmin(UserAdmin):
+    form = UserChangeForm
+    add_form = CustomUserCreationForm
     model = User
     list_display = ('username', 'email', 'account_type', 'is_staff', 'is_superuser')
+    
     fieldsets = UserAdmin.fieldsets + (
         (None, {'fields': ('phone_number', 'date_of_birth', 'hometown', 
                           'job_or_university', 'favorite_drink', 'location', 
-                          'account_type', 'vote_weight')}),  # Removed profile_picture
+                          'account_type', 'vote_weight')}),
     )
+    
+    add_fieldsets = (
+        (None, {
+            'classes': ('wide',),
+            'fields': ('username', 'email', 'password1', 'password2'),
+        }),
+    )
+    
     inlines = [ProfilePictureInline]
+    
+    def get_inlines(self, request, obj=None):
+        # Only show profile pictures for existing users
+        if obj is None:  # obj is None when adding a new user
+            return []
+        return [ProfilePictureInline]
+    
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                '<path:object_id>/upload-picture/',
+                self.admin_site.admin_view(self.upload_picture_view),
+                name='users_user_upload_picture',
+            ),
+        ]
+        return custom_urls + urls
+    
+    def upload_picture_view(self, request, object_id):
+        user = self.get_queryset(request).get(pk=object_id)
+        
+        if request.method == 'POST':
+            form = UploadPictureForm(request.POST, request.FILES)
+            if form.is_valid():
+                # Use the same logic as your API endpoint
+                serializer = ProfilePictureSerializer(data={'image': request.FILES['image']})
+                if serializer.is_valid():
+                    serializer.save(user=user)
+                    self.message_user(request, "Profile picture uploaded successfully")
+                    return redirect('..')
+                else:
+                    form.add_error('image', serializer.errors)
+        else:
+            form = UploadPictureForm()
+            
+        context = {
+            'form': form,
+            'title': f'Upload profile picture for {user.username}',
+            'opts': self.model._meta,
+        }
+        return render(request, 'admin/upload_picture_form.html', context)
+    
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        extra_context = extra_context or {}
+        extra_context['show_upload_button'] = True
+        extra_context['upload_url'] = f'upload-picture/'
+        return super().change_view(request, object_id, form_url, extra_context)

--- a/backend/apps/users/authentication.py
+++ b/backend/apps/users/authentication.py
@@ -32,3 +32,5 @@ class FirebaseAuthentication(BaseAuthentication):
             raise AuthenticationFailed('User not found')
 
         return (user, None)
+    
+    

--- a/backend/barbuddy_api/authentication.py
+++ b/backend/barbuddy_api/authentication.py
@@ -2,6 +2,7 @@
 
 import firebase_admin
 from firebase_admin import auth, credentials
+from firebase_admin.exceptions import FirebaseError
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 from django.contrib.auth import get_user_model
@@ -18,10 +19,10 @@ SERVICE_ACCOUNT_PATH = os.path.join(BASE_DIR, 'firebase', 'service-account.json'
 
 # Only initialize once
 if not firebase_admin._apps:
-    logger.info(f"Initializing Firebase Admin with service account at: {SERVICE_ACCOUNT_PATH}")
+    logger.info(f"Initializing Firebase Admin with service account")
     if not os.path.exists(SERVICE_ACCOUNT_PATH):
-        logger.error(f"Service account file not found at: {SERVICE_ACCOUNT_PATH}")
-        raise FileNotFoundError(f"Service account file not found at: {SERVICE_ACCOUNT_PATH}")
+        logger.error("Service account file not found")
+        raise FileNotFoundError("Service account file not found")
     
     cred = credentials.Certificate(SERVICE_ACCOUNT_PATH)
     firebase_admin.initialize_app(cred)
@@ -29,154 +30,162 @@ if not firebase_admin._apps:
 
 class FirebaseAuthentication(BaseAuthentication):
     def authenticate(self, request):
-        # Log all headers for debugging
-        logger.info(f"All request headers: {dict(request.headers)}")
-        logger.info(f"All META data: {dict(request.META)}")
+        # Don't log all headers - this exposes sensitive information
+        logger.info("Processing authentication request")
         
         # Try different header names for Authorization
         auth_header = None
         header_names = [
             'Authorization',
             'HTTP_AUTHORIZATION',
-            'HTTP_AUTH',
             'HTTP_X_AUTHORIZATION',
-            'X-Authorization',
-            'authorization'  # Add lowercase version
         ]
         
         for header_name in header_names:
             # Try direct header access
             auth_header = request.headers.get(header_name)
             if auth_header:
-                logger.info(f"Found Authorization header in headers[{header_name}]: {auth_header}")
+                logger.info(f"Found Authorization header")
                 break
                 
-            # Try META access
-            auth_header = request.META.get(header_name)
-            if auth_header:
-                logger.info(f"Found Authorization header in META[{header_name}]: {auth_header}")
-                break
-                
-            # Try HTTP_ prefixed META access
-            http_header = f"HTTP_{header_name.upper()}"
+            # Try META access with HTTP_ prefix
+            http_header = f"HTTP_{header_name.upper()}" if not header_name.startswith('HTTP_') else header_name
             auth_header = request.META.get(http_header)
             if auth_header:
-                logger.info(f"Found Authorization header in META[{http_header}]: {auth_header}")
+                logger.info(f"Found Authorization header in META")
                 break
 
         if not auth_header:
-            logger.warning("No Authorization header found in any location")
-            # Log all available headers and META data for debugging
-            logger.info("Available headers:")
-            for key, value in request.headers.items():
-                logger.info(f"  {key}: {value}")
-            logger.info("Available META data:")
-            for key, value in request.META.items():
-                if key.startswith('HTTP_'):
-                    logger.info(f"  {key}: {value}")
+            logger.warning("No Authorization header found")
             return None
 
         # Clean up the header value
         auth_header = auth_header.strip()
         if not auth_header.startswith("Bearer "):
-            logger.warning(f"Authorization header does not start with 'Bearer ': {auth_header}")
+            logger.warning("Authorization header does not start with 'Bearer'")
             return None
 
         try:
             id_token = auth_header.split(" ")[1]  # Get the token part after "Bearer "
-            logger.info(f"Extracted token: {id_token[:10]}...")  # Log first 10 chars for security
+            logger.info("Token extracted, beginning verification")
 
-            logger.info("Attempting to verify Firebase ID token")
-            decoded_token = auth.verify_id_token(id_token)
-            uid = decoded_token['uid']
-            logger.info(f"Successfully verified token for user: {uid}")
+            # Specific Firebase token verification exceptions
+            try:
+                logger.info("Attempting to verify Firebase ID token")
+                decoded_token = auth.verify_id_token(id_token)
+                uid = decoded_token.get('uid')
+                if not uid:
+                    logger.error("No UID found in decoded token")
+                    raise AuthenticationFailed('Invalid token format')
+                logger.info(f"Successfully verified token")
+            except auth.InvalidIdTokenError:
+                logger.warning("Invalid token")
+                raise AuthenticationFailed('Invalid token')
+            except auth.ExpiredIdTokenError:
+                logger.warning("Expired token")
+                raise AuthenticationFailed('Token expired')
+            except auth.RevokedIdTokenError:
+                logger.warning("Revoked token")
+                raise AuthenticationFailed('Token revoked')
+            except FirebaseError as e:
+                logger.error(f"Firebase error: {str(e)}")
+                raise AuthenticationFailed('Authentication error')
+
+            User = get_user_model()
+            try:
+                user = User.objects.get(username=uid)
+                logger.info(f"Found existing user")
+                
+                # If this is a POST request to /api/users/, update the user's profile
+                if request.method == 'POST' and request.path == '/api/users/':
+                    try:
+                        data = request.data
+                        logger.info("Updating user profile")
+                        
+                        # Update user fields - don't log the data
+                        self._update_user_fields(user, data)
+                        
+                        user.save()
+                        logger.info(f"Successfully updated user profile")
+                    except ValueError as e:
+                        logger.error(f"Value error: {str(e)}")
+                        raise AuthenticationFailed(f'Value error: {str(e)}')
+                    except Exception as e:
+                        logger.error(f"Error updating user profile")
+                        raise AuthenticationFailed('Error updating user profile')
+            except User.DoesNotExist:
+                # If this is a POST request to /api/users/, create a new user with profile data
+                if request.method == 'POST' and request.path == '/api/users/':
+                    try:
+                        data = request.data
+                        logger.info("Creating new user")
+                        
+                        # Create user with profile data
+                        user = self._create_user_with_data(uid, data)
+                        
+                        logger.info("Successfully created new user")
+                    except ValueError as e:
+                        logger.error(f"Value error: {str(e)}")
+                        raise AuthenticationFailed(f'Value error: {str(e)}')
+                    except Exception as e:
+                        logger.error("Error creating user")
+                        raise AuthenticationFailed('Error creating user')
+                else:
+                    # For non-POST requests, create a basic user with UID
+                    user = User.objects.create(username=uid)
+                    logger.info("Created new user with basic info")
+                
+            return (user, None)
+        except IndexError:
+            logger.warning("Malformed Authorization header")
+            return None
         except Exception as e:
-            logger.error(f"Token verification failed: {str(e)}")
-            raise AuthenticationFailed(f'Invalid Firebase ID token: {str(e)}')
+            logger.error(f"Unexpected authentication error: {type(e).__name__}")
+            raise AuthenticationFailed('Authentication failed')
 
-        User = get_user_model()
-        try:
-            user = User.objects.get(username=uid)
-            logger.info(f"Found existing user with UID: {uid}")
-            
-            # If this is a POST request to /api/users/, update the user's profile
-            if request.method == 'POST' and request.path == '/api/users/':
-                try:
-                    data = request.data
-                    logger.info(f"Updating user profile with data: {data}")
-                    
-                    # Update user fields
-                    if 'username' in data:
-                        user.username = data['username']
-                    if 'first_name' in data:
-                        user.first_name = data['first_name']
-                    if 'last_name' in data:
-                        user.last_name = data['last_name']
-                    if 'email' in data:
-                        user.email = data['email']
-                    if 'date_of_birth' in data:
-                        # Convert string date to date object
-                        date_str = data['date_of_birth']
-                        try:
-                            date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
-                            user.date_of_birth = date_obj
-                        except ValueError as e:
-                            logger.error(f"Invalid date format: {date_str}")
-                            raise AuthenticationFailed(f'Invalid date format: {date_str}')
-                    if 'hometown' in data:
-                        user.hometown = data['hometown']
-                    if 'job_or_university' in data:
-                        user.job_or_university = data['job_or_university']
-                    if 'favorite_drink' in data:
-                        user.favorite_drink = data['favorite_drink']
-                    if 'sexual_preference' in data:
-                        user.sexual_preference = data['sexual_preference']
-                    if 'account_type' in data:
-                        user.account_type = data['account_type']
-                    
-                    user.save()
-                    logger.info(f"Successfully updated user profile for UID: {uid}")
-                except Exception as e:
-                    logger.error(f"Error updating user profile: {str(e)}")
-                    raise AuthenticationFailed(f'Error updating user profile: {str(e)}')
-        except User.DoesNotExist:
-            # If this is a POST request to /api/users/, create a new user with profile data
-            if request.method == 'POST' and request.path == '/api/users/':
-                try:
-                    data = request.data
-                    logger.info(f"Creating new user with data: {data}")
-                    
-                    # Create user with profile data
-                    user = User.objects.create(
-                        username=data.get('username', uid),  # Use provided username or UID
-                        first_name=data.get('first_name', ''),
-                        last_name=data.get('last_name', ''),
-                        email=data.get('email', ''),
-                        hometown=data.get('hometown', ''),
-                        job_or_university=data.get('job_or_university', ''),
-                        favorite_drink=data.get('favorite_drink', ''),
-                        sexual_preference=data.get('sexual_preference', ''),
-                        account_type=data.get('account_type', '')
-                    )
-                    
-                    # Handle date_of_birth separately
-                    if 'date_of_birth' in data:
-                        date_str = data['date_of_birth']
-                        try:
-                            date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
-                            user.date_of_birth = date_obj
-                        except ValueError as e:
-                            logger.error(f"Invalid date format: {date_str}")
-                            raise AuthenticationFailed(f'Invalid date format: {date_str}')
-                    
-                    user.save()
-                    logger.info(f"Successfully created new user with UID: {uid}")
-                except Exception as e:
-                    logger.error(f"Error creating user: {str(e)}")
-                    raise AuthenticationFailed(f'Error creating user: {str(e)}')
-            else:
-                # For non-POST requests, create a basic user with UID
-                user = User.objects.create(username=uid)
-                logger.info(f"Created new user with UID: {uid}")
-            
-        return (user, None)
+    def _update_user_fields(self, user, data):
+        """Helper method to update user fields from data"""
+        fields = [
+            'username', 'first_name', 'last_name', 'email', 
+            'hometown', 'job_or_university', 'favorite_drink', 
+            'sexual_preference', 'account_type'
+        ]
+        
+        for field in fields:
+            if field in data:
+                setattr(user, field, data[field])
+                
+        # Handle date_of_birth separately
+        if 'date_of_birth' in data:
+            date_str = data['date_of_birth']
+            try:
+                date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
+                user.date_of_birth = date_obj
+            except ValueError:
+                raise ValueError(f'Invalid date format. Use YYYY-MM-DD format.')
+    
+    def _create_user_with_data(self, uid, data):
+        """Helper method to create a user with the given data"""
+        user = get_user_model().objects.create(
+            username=data.get('username', uid),
+            first_name=data.get('first_name', ''),
+            last_name=data.get('last_name', ''),
+            email=data.get('email', ''),
+            hometown=data.get('hometown', ''),
+            job_or_university=data.get('job_or_university', ''),
+            favorite_drink=data.get('favorite_drink', ''),
+            sexual_preference=data.get('sexual_preference', ''),
+            account_type=data.get('account_type', '')
+        )
+        
+        # Handle date_of_birth separately
+        if 'date_of_birth' in data:
+            date_str = data['date_of_birth']
+            try:
+                date_obj = datetime.strptime(date_str, '%Y-%m-%d').date()
+                user.date_of_birth = date_obj
+            except ValueError:
+                raise ValueError(f'Invalid date format. Use YYYY-MM-DD format.')
+        
+        user.save()
+        return user


### PR DESCRIPTION
Ok, so what I found is that the GET /api/user/ endpoint was behaiving a little weird. It only got a single user. So what I did was actually just deactivate it.   Our active endpoints to retrieve users are 
- GET /api/users/list_all_users/
- Get /api/users/{id}/
￼
<img width="992" alt="Screenshot 2025-05-13 at 11 34 56 AM" src="https://github.com/user-attachments/assets/322d65f6-5dd3-4b62-acf6-e8c6df550780" />

<img width="1022" alt="Screenshot 2025-05-13 at 11 35 17 AM" src="https://github.com/user-attachments/assets/64099653-0063-4ccc-b133-34f1265fba82" />

￼
  I also fixed our /users/register_user/ endpoint. Something was wrong with its logic when Jacob implemented it. As before if an account with a “taken email” was attempted to be created it would still go through to our database creating an account with a username that same user wouldn’t be able to use anymore cause it was now “taken”.   Heres a screenshot of GET /users/{id} in action after fixing /register_users/
  
￼
<img width="679" alt="Screenshot 2025-05-13 at 11 57 47 AM" src="https://github.com/user-attachments/assets/65ae9fdb-d748-4f90-9150-d22ffc7cc98b" />

   I went ahead and cleared ALL of our user accounts except for our SuperUsers (for dev reasons), and added a couple accounts with all of the fields like profile images and all that. The ID’s are right here:    
￼
<img width="885" alt="Screenshot 2025-05-13 at 3 41 52 PM" src="https://github.com/user-attachments/assets/69d8e489-e999-448a-a2f0-6c2c2386469e" />

 These test accounts all have their own profile pictures, and Tommy has a match with Ashley:   Example GET : api/users/117/ Tommy:  
￼

<img width="644" alt="Screenshot 2025-05-13 at 3 46 22 PM" src="https://github.com/user-attachments/assets/c7e67f6e-9620-420e-bb45-de247a2422e9" />

 I also changed the /list_all_users/ to return ONLY the ID and username of EVERY user in the database.  *important -> i also included pagnation to the list_all_users.  this means that instead of returning EVERYSINGLE user on our database, it only includes around 20 max. The endpoint includes a step to get to the second page now as well “next”. Next is null at the time of the screenshot because our database was wiped of test users.   
￼
<img width="710" alt="Screenshot 2025-05-13 at 12 26 43 PM" src="https://github.com/user-attachments/assets/69e57915-3538-405e-930d-9601c9e8df1a" />

  For now i think the flow is: 
1. GET users/list_all_users/ -> which returns all of the user’s ID’s,
2. GET users/{ID} to display the user’s data 

Bassically, Our default GET / POST    /user/ endpoint is something that Django likes to implement by default. I essentially turned those off so they are useless. 


Also here is a Match Between Two of our test users:  
￼
  
<img width="1045" alt="Screenshot 2025-05-13 at 3 38 26 PM" src="https://github.com/user-attachments/assets/6f56fe4b-ac49-474f-9402-56a528c16f10" />
